### PR TITLE
add font integregration

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,9 +1,15 @@
 import { StatusBar } from "expo-status-bar";
 import { LogBox, StyleSheet, Text, View, TouchableOpacity } from "react-native";
 import { Button } from "react-native-web";
+import { useFonts, Montserrat_300Light, Montserrat_400Regular, Montserrat_600SemiBold} from "@expo-google-fonts/montserrat";
 
 export default function App() {
   const onPress = () => console.log("Casual mode has been clicked");
+  let [fontsLoaded] = useFonts({
+    Montserrat_300Light,
+    Montserrat_400Regular,
+    Montserrat_600SemiBold
+  })
 
   return (
     <View style={styles.background}>
@@ -33,12 +39,11 @@ const styles = StyleSheet.create({
     paddingRight: 16,
   },
   topperTitle: {
-    fontFamily: "Montserrat",
+    fontFamily: "Montserrat_300Light",
     fontSize: 24,
-    fontStyle: "normal",
   },
   realTitle: {
-    fontFamily: "Montserrat",
+    fontFamily: "Montserrat_600SemiBold",
     fontSize: 32,
     fontStyle: "normal",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "that-party-game",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/montserrat": "^0.2.2",
         "expo": "~45.0.0",
+        "expo-font": "~10.1.0",
         "expo-status-bar": "~1.3.0",
         "react": "17.0.2",
         "react-dom": "17.0.2",
@@ -1781,6 +1783,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@expo-google-fonts/montserrat": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/montserrat/-/montserrat-0.2.2.tgz",
+      "integrity": "sha512-kpK++6mnyPPNVuZQ5ScU/YmvNsbDQGNgxwPgkmAKFrctAhfwg4KxotmmuNnn2ZaKLPtGYjP8/M8JIO3/tAm9ag=="
     },
     "node_modules/@expo/bunyan": {
       "version": "4.0.0",
@@ -13503,6 +13510,11 @@
         "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@expo-google-fonts/montserrat": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/montserrat/-/montserrat-0.2.2.tgz",
+      "integrity": "sha512-kpK++6mnyPPNVuZQ5ScU/YmvNsbDQGNgxwPgkmAKFrctAhfwg4KxotmmuNnn2ZaKLPtGYjP8/M8JIO3/tAm9ag=="
     },
     "@expo/bunyan": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@expo-google-fonts/montserrat": "^0.2.2",
     "expo": "~45.0.0",
+    "expo-font": "~10.1.0",
     "expo-status-bar": "~1.3.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",


### PR DESCRIPTION
# What

Integrationf for `Montserrat` fonts, as it is the one we decied on in the figma design.

# Proof that it works:
See the title:
![fontsss](https://user-images.githubusercontent.com/34132543/183249405-79fe88cd-c4ea-402c-a4da-f968f57b69d7.PNG)

#How to integrate?

In yout styles, you dont need to add a `fontFamily` and `fontStyle` anymore. You just add `fontFamily`. It its name (and import)  they already have the correct `fontStyle`
